### PR TITLE
Drop terraform run constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 85878641f3e3912948c694530fe015c8af8d1d1039f168336859ac85cb028d96
 
 build:
-  number: 0
+  number: 1
   script:
     - go install -v -ldflags "-X main.VERSION={{ version }}" .
 
@@ -20,7 +20,7 @@ requirements:
   build:
     - {{ compiler('go') }}
   run:
-    - terraform >=0.15.1,<0.16.0
+    - terraform
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This relaxes the run constraint in light of terraform 1.0 being released. Users can specify their constraints via https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#terraform_version_constraint and manage their environments accordingly. 