### PR TITLE
feat(recipe): load terragrunt shell completion on env activation

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -13,6 +13,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
@@ -21,15 +24,15 @@ jobs:
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
-      export MINIFORGE_HOME=$(tools_install_dir)
-      export CONDA_BLD_PATH=$(build_workspace_dir)
       export CI=azure
+      export CONDA_BLD_PATH=$(build_workspace_dir)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export MINIFORGE_HOME=$(tools_install_dir)
+      export OSX_FORCE_SDK_DOWNLOAD="1"
       export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
       export remote_url=$(Build.Repository.Uri)
       export sha=$(Build.SourceVersion)
-      export OSX_FORCE_SDK_DOWNLOAD="1"
-      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
         export IS_PR_BUILD="True"
       else

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -12,6 +12,9 @@ jobs:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
         build_workspace_dir: D:\\bld\\
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: D:\Miniforge
   timeoutInMinutes: 360
@@ -19,21 +22,20 @@ jobs:
     UPLOAD_TEMP: D:\\tmp
 
   steps:
-
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
-        MINIFORGE_HOME: $(tools_install_dir)
-        CONDA_BLD_PATH: $(build_workspace_dir)
-        PYTHONUNBUFFERED: 1
-        CONFIG: $(CONFIG)
         CI: azure
+        CONFIG: $(CONFIG)
+        CONDA_BLD_PATH: $(build_workspace_dir)
+        MINIFORGE_HOME: $(tools_install_dir)
+        PYTHONUNBUFFERED: 1
+        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
+        UPLOAD_TEMP: $(UPLOAD_TEMP)
         flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
         remote_url: $(Build.Repository.Uri)
         sha: $(Build.SourceVersion)
-        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
-        UPLOAD_TEMP: $(UPLOAD_TEMP)
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
         FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
         STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,80 +23,89 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-            tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Configure binfmt_misc
+      if: matrix.os == 'ubuntu'
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
 
     - name: Build on Linux
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        CONFIG: ${{ matrix.CONFIG }}
-        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONDA_FORGE_DOCKER_RUN_ARGS: ${{ matrix.docker_run_args }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
+        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
-        if [[ "$(uname -m)" == "x86_64" ]]; then
-          echo "::group::Configure binfmt_misc"
-          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
-        fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
-        echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CI: github_actions
         CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        CI: github_actions
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -109,12 +118,14 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
-        PYTHONUNBUFFERED: 1
-        CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
+        CONFIG: ${{ matrix.CONFIG }}
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        PYTHONUNBUFFERED: 1
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -58,18 +58,33 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    conda debug \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
+        ${BUILD_OUTPUT_ID:+--output-id "${BUILD_OUTPUT_ID}"} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
     # Drop into an interactive shell
     /bin/bash
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
+    conda-build \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --suppress-variables \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -107,17 +115,20 @@ ${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
 ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
-           -e CONFIG \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           -e IS_PR_BUILD \
-           -e GIT_BRANCH \
-           -e UPLOAD_ON_BRANCH \
-           -e CI \
-           -e FEEDSTOCK_NAME \
-           -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e CI \
+           -e CONFIG \
+           -e CPU_COUNT \
+           -e FEEDSTOCK_NAME \
+           -e GIT_BRANCH \
+           -e GITHUB_ACTIONS \
+           -e HOST_USER_ID \
+           -e IS_PR_BUILD \
+           -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e UPLOAD_ON_BRANCH \
+           -e UPLOAD_PACKAGES \
            -e flow_run_id \
            -e remote_url \
            -e sha \

--- a/build-locally.py
+++ b/build-locally.py
@@ -98,7 +98,10 @@ def main(args=None):
     p.add_argument(
         "--debug",
         action="store_true",
-        help="Setup debug environment using `conda debug`",
+        help=(
+            "Setup debug environment using `conda debug` "
+            "(or `rattler-build debug` for rattler-build recipes)"
+        ),
     )
     p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 

--- a/recipe/activate.fish
+++ b/recipe/activate.fish
@@ -1,0 +1,1 @@
+complete -c terragrunt -f -a "(env COMP_LINE=(commandline -cp) terragrunt)"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,6 @@
+if [ -n "${BASH_VERSION:-}" ]; then
+    complete -C terragrunt terragrunt
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    autoload -U +X bashcompinit && bashcompinit
+    complete -C terragrunt terragrunt
+fi

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,6 +1,7 @@
 if [ -n "${BASH_VERSION:-}" ]; then
     complete -C terragrunt terragrunt
 elif [ -n "${ZSH_VERSION:-}" ]; then
+    autoload -U +X compinit && compinit -u
     autoload -U +X bashcompinit && bashcompinit
     complete -C terragrunt terragrunt
 fi

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
-go install -v -ldflags "-X main.VERSION=%PKG_VERSION%" .
+go install -v -ldflags "-X github.com/gruntwork-io/terragrunt/internal/version.Version=v%PKG_VERSION%" .
 if errorlevel 1 exit 1
 
 for %%C in (activate deactivate) do (

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,10 @@
+go install -v -ldflags "-X main.VERSION=%PKG_VERSION%" .
+if errorlevel 1 exit 1
+
+for %%C in (activate deactivate) do (
+    if not exist "%PREFIX%\etc\conda\%%C.d" mkdir "%PREFIX%\etc\conda\%%C.d"
+    copy /Y "%RECIPE_DIR%\%%C.sh"   "%PREFIX%\etc\conda\%%C.d\%PKG_NAME%_%%C.sh"
+    if errorlevel 1 exit 1
+    copy /Y "%RECIPE_DIR%\%%C.fish" "%PREFIX%\etc\conda\%%C.d\%PKG_NAME%_%%C.fish"
+    if errorlevel 1 exit 1
+)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+go install -v -ldflags "-X main.VERSION=${PKG_VERSION}" .
+
+for change in activate deactivate; do
+    mkdir -p "${PREFIX}/etc/conda/${change}.d"
+    cp "${RECIPE_DIR}/${change}.sh"   "${PREFIX}/etc/conda/${change}.d/${PKG_NAME}_${change}.sh"
+    cp "${RECIPE_DIR}/${change}.fish" "${PREFIX}/etc/conda/${change}.d/${PKG_NAME}_${change}.fish"
+done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-go install -v -ldflags "-X main.VERSION=${PKG_VERSION}" .
+go install -v -ldflags "-X github.com/gruntwork-io/terragrunt/internal/version.Version=v${PKG_VERSION}" .
 
 for change in activate deactivate; do
     mkdir -p "${PREFIX}/etc/conda/${change}.d"

--- a/recipe/deactivate.fish
+++ b/recipe/deactivate.fish
@@ -1,0 +1,1 @@
+complete -e -c terragrunt

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,3 @@
+if [ -n "${BASH_VERSION:-}" ] || [ -n "${ZSH_VERSION:-}" ]; then
+    complete -r terragrunt 2>/dev/null || true
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,23 @@ requirements:
     - terraform
 
 test:
+  requires:
+    - fish  # [unix]
+    - zsh   # [unix]
   commands:
     - {{ name|lower }} --version
     - {{ name|lower }} --help
-    - test -f $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.sh      # [unix]
-    - test -f $PREFIX/etc/conda/deactivate.d/{{ name|lower }}_deactivate.sh  # [unix]
+    - test -f $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.sh        # [unix]
+    - test -f $PREFIX/etc/conda/deactivate.d/{{ name|lower }}_deactivate.sh    # [unix]
+    - test -f $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.fish      # [unix]
+    - test -f $PREFIX/etc/conda/deactivate.d/{{ name|lower }}_deactivate.fish  # [unix]
     - bash -c 'source $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.sh && complete -p {{ name|lower }} | grep -q {{ name|lower }}'      # [unix]
-    - if not exist %PREFIX%\etc\conda\activate.d\{{ name|lower }}_activate.sh exit 1      # [win]
-    - if not exist %PREFIX%\etc\conda\deactivate.d\{{ name|lower }}_deactivate.sh exit 1  # [win]
+    - zsh  -c 'source $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.sh && complete -p {{ name|lower }} | grep -q {{ name|lower }}'      # [unix]
+    - fish -c 'source $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.fish; complete -c {{ name|lower }} | grep -q {{ name|lower }}'      # [unix]
+    - if not exist "%PREFIX%\etc\conda\activate.d\{{ name|lower }}_activate.sh" exit 1        # [win]
+    - if not exist "%PREFIX%\etc\conda\deactivate.d\{{ name|lower }}_deactivate.sh" exit 1    # [win]
+    - if not exist "%PREFIX%\etc\conda\activate.d\{{ name|lower }}_activate.fish" exit 1      # [win]
+    - if not exist "%PREFIX%\etc\conda\deactivate.d\{{ name|lower }}_deactivate.fish" exit 1  # [win]
 
 about:
   home: https://www.gruntwork.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ source:
 
 build:
   number: 0
-  script:
-    - go install -v -ldflags "-X main.VERSION={{ version }}" .
 
 requirements:
   build:
@@ -26,6 +24,11 @@ test:
   commands:
     - {{ name|lower }} --version
     - {{ name|lower }} --help
+    - test -f $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.sh      # [unix]
+    - test -f $PREFIX/etc/conda/deactivate.d/{{ name|lower }}_deactivate.sh  # [unix]
+    - bash -c 'source $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.sh && complete -p {{ name|lower }} | grep -q {{ name|lower }}'      # [unix]
+    - if not exist %PREFIX%\etc\conda\activate.d\{{ name|lower }}_activate.sh exit 1      # [win]
+    - if not exist %PREFIX%\etc\conda\deactivate.d\{{ name|lower }}_deactivate.sh exit 1  # [win]
 
 about:
   home: https://www.gruntwork.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: a5cdd3703944646d5d3cf2ee0b168e1b5b4873fa40fc0e558f59e9286455746d
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ test:
     - zsh   # [unix]
   commands:
     - {{ name|lower }} --version
+    - {{ name|lower }} --version | grep -q "v{{ version }}"  # [unix]
     - {{ name|lower }} --help
     - test -f $PREFIX/etc/conda/activate.d/{{ name|lower }}_activate.sh        # [unix]
     - test -f $PREFIX/etc/conda/deactivate.d/{{ name|lower }}_deactivate.sh    # [unix]


### PR DESCRIPTION
Registers terragrunt shell completion automatically when the conda env activates.
- `complete -C terragrunt terragrunt` for bash (and zsh via `bashcompinit`)
- equivalent `COMP_LINE` passthrough for fish
- symmetric deactivate scripts clear the binding
- build moves from inline `meta.yaml` into `recipe/build.sh` + `recipe/bld.bat` so the activate/deactivate scripts can be copied into `$PREFIX/etc/conda/{activate,deactivate}.d/`
- Fixes wrong build version reported by the `terragrunt` binary